### PR TITLE
Updated library to make this more flexible and support iOS 13 API

### DIFF
--- a/Sources/DataCache.swift
+++ b/Sources/DataCache.swift
@@ -76,7 +76,7 @@ extension DataCache {
                 do {
                     try self.fileManager.createDirectory(atPath: self.cachePath, withIntermediateDirectories: true, attributes: nil)
                 } catch {
-                    print("DataCache: Error while creating cache folder: \(error.localizedDescription)")
+                    assertionFailure("DataCache: Error while creating cache folder: \(error.localizedDescription)")
                 }
             }
 
@@ -122,11 +122,11 @@ extension DataCache {
     public func write(object: NSCoding, forKey key: String, alsoOnDisk: Bool = false) {
         var dataToWrite: Data = Data()
         if #available(iOS 13, *) {
-            if let dataToSave = try? NSKeyedArchiver.archivedData(withRootObject: object, requiringSecureCoding: false) {
-                dataToWrite = dataToSave
+            do {
+                dataToWrite = try NSKeyedArchiver.archivedData(withRootObject: object, requiringSecureCoding: false)
+            } catch {
+                assertionFailure("data to save not found: \(error.localizedDescription)")
             }
-
-            assertionFailure("data to save not found")
         } else {
             dataToWrite = NSKeyedArchiver.archivedData(withRootObject: object)
         }
@@ -385,7 +385,7 @@ extension DataCache {
         if #available(iOS 13, *) {
             fileName = key.md5String
         } else {
-            fileName =  = key.md5
+            fileName = key.md5
         }
 
         return (cachePath as NSString).appendingPathComponent(fileName)

--- a/Sources/DataCache.swift
+++ b/Sources/DataCache.swift
@@ -12,46 +12,47 @@ public enum ImageFormat {
     case unknown, png, jpeg
 }
 
+// swiftlint:disable force_unwrapping attributes large_tuple closure_body_length trailing_closure
 open class DataCache {
     static let cacheDirectoryPrefix = "com.nch.cache."
     static let ioQueuePrefix = "com.nch.queue."
     static let defaultMaxCachePeriodInSecond: TimeInterval = 60 * 60 * 24 * 7         // a week
-    
+
     public static let instance = DataCache(name: "default")
-    
+
     let cachePath: String
-    
+
     let memCache = NSCache<AnyObject, AnyObject>()
     let ioQueue: DispatchQueue
     let fileManager: FileManager
-    
+
     /// Name of cache
     open var name: String = ""
-    
+
     /// Life time of disk cache, in second. Default is a week
     open var maxCachePeriodInSecond = DataCache.defaultMaxCachePeriodInSecond
-    
+
     /// Size is allocated for disk cache, in byte. 0 mean no limit. Default is 0
     open var maxDiskCacheSize: UInt = 0
-    
+
     /// Specify distinc name param, it represents folder name for disk cache
     public init(name: String, path: String? = nil) {
         self.name = name
-        
+
         var cachePath = path ?? NSSearchPathForDirectoriesInDomains(.cachesDirectory, FileManager.SearchPathDomainMask.userDomainMask, true).first!
         cachePath = (cachePath as NSString).appendingPathComponent(DataCache.cacheDirectoryPrefix + name)
         self.cachePath = cachePath
-        
+
         ioQueue = DispatchQueue(label: DataCache.ioQueuePrefix + name)
-        
+
         self.fileManager = FileManager()
-        
+
         #if !os(OSX) && !os(watchOS)
             NotificationCenter.default.addObserver(self, selector: #selector(cleanExpiredDiskCache), name: UIApplication.willTerminateNotification, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(cleanExpiredDiskCache), name: UIApplication.didEnterBackgroundNotification, object: nil)
         #endif
     }
-    
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -60,13 +61,15 @@ open class DataCache {
 // MARK: - Store data
 
 extension DataCache {
-    
+
     /// Write data for key. This is an async operation.
-    public func write(data: Data, forKey key: String) {
+    public func write(data: Data, forKey key: String, alsoOnDisk: Bool = false) {
         memCache.setObject(data as AnyObject, forKey: key as AnyObject)
-        writeDataToDisk(data: data, key: key)
+        if alsoOnDisk {
+            writeDataToDisk(data: data, key: key)
+        }
     }
-    
+
     private func writeDataToDisk(data: Data, key: String) {
         ioQueue.async {
             if self.fileManager.fileExists(atPath: self.cachePath) == false {
@@ -76,121 +79,134 @@ extension DataCache {
                     print("DataCache: Error while creating cache folder: \(error.localizedDescription)")
                 }
             }
-            
+
             self.fileManager.createFile(atPath: self.cachePath(forKey: key), contents: data, attributes: nil)
         }
     }
-    
+
     /// Read data for key
-    public func readData(forKey key:String) -> Data? {
+    public func readData(forKey key: String) -> Data? {
         var data = memCache.object(forKey: key as AnyObject) as? Data
-        
+
         if data == nil {
             if let dataFromDisk = readDataFromDisk(forKey: key) {
                 data = dataFromDisk
                 memCache.setObject(dataFromDisk as AnyObject, forKey: key as AnyObject)
             }
         }
-        
+
         return data
     }
-    
+
     /// Read data from disk for key
     public func readDataFromDisk(forKey key: String) -> Data? {
         return self.fileManager.contents(atPath: cachePath(forKey: key))
     }
-    
+
     // MARK: - Read & write Codable types
-    public func write<T: Encodable>(codable: T, forKey key: String) throws {
+    public func write<T: Encodable>(codable: T, forKey key: String, alsoOnDisk: Bool = false) throws {
         let data = try JSONEncoder().encode(codable)
-        write(data: data, forKey: key)
+        write(data: data, forKey: key, alsoOnDisk: alsoOnDisk)
     }
-    
+
     public func readCodable<T: Decodable>(forKey key: String) throws -> T? {
         guard let data = readData(forKey: key) else { return nil }
         return try JSONDecoder().decode(T.self, from: data)
     }
-    
+
     // MARK: - Read & write primitive types
-    
-    
+
     /// Write an object for key. This object must inherit from `NSObject` and implement `NSCoding` protocol. `String`, `Array`, `Dictionary` conform to this method.
     ///
     /// NOTE: Can't write `UIImage` with this method. Please use `writeImage(_:forKey:)` to write an image
-    public func write(object: NSCoding, forKey key: String) {
-        let data = NSKeyedArchiver.archivedData(withRootObject: object)
-        write(data: data, forKey: key)
+    public func write(object: NSCoding, forKey key: String, alsoOnDisk: Bool = false) {
+        var dataToWrite: Data = Data()
+        if #available(iOS 13, *) {
+            if let dataToSave = try? NSKeyedArchiver.archivedData(withRootObject: object, requiringSecureCoding: false) {
+                dataToWrite = dataToSave
+            }
+
+            assertionFailure("data to save not found")
+        } else {
+            dataToWrite = NSKeyedArchiver.archivedData(withRootObject: object)
+        }
+
+        write(data: dataToWrite, forKey: key, alsoOnDisk: alsoOnDisk)
     }
-    
+
     /// Write a string for key
-    public func write(string: String, forKey key: String) {
-        write(object: string as NSCoding, forKey: key)
+    public func write(string: String, forKey key: String, alsoOnDisk: Bool = false) {
+        write(object: string as NSCoding, forKey: key, alsoOnDisk: alsoOnDisk)
     }
-    
+
     /// Write a dictionary for key
-    public func write(dictionary: Dictionary<AnyHashable, Any>, forKey key: String) {
-        write(object: dictionary as NSCoding, forKey: key)
+    public func write(dictionary: [AnyHashable: Any], forKey key: String, alsoOnDisk: Bool = false) {
+        write(object: dictionary as NSCoding, forKey: key, alsoOnDisk: alsoOnDisk)
     }
-    
+
     /// Write an array for key
-    public func write(array: Array<Any>, forKey key: String) {
-        write(object: array as NSCoding, forKey: key)
+    public func write(array: [Any], forKey key: String, alsoOnDisk: Bool = false) {
+        write(object: array as NSCoding, forKey: key, alsoOnDisk: alsoOnDisk)
     }
-    
+
     /// Read an object for key. This object must inherit from `NSObject` and implement NSCoding protocol. `String`, `Array`, `Dictionary` conform to this method
     public func readObject(forKey key: String) -> NSObject? {
         let data = readData(forKey: key)
-        
         if let data = data {
-            return NSKeyedUnarchiver.unarchiveObject(with: data) as? NSObject
+            if #available(iOS 13, *) {
+                if let loadObject = try? NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as? NSObject {
+                    return loadObject
+                }
+            } else {
+                return NSKeyedUnarchiver.unarchiveObject(with: data) as? NSObject
+            }
         }
-        
+
         return nil
     }
-    
+
     /// Read a string for key
     public func readString(forKey key: String) -> String? {
         return readObject(forKey: key) as? String
     }
-    
+
     /// Read an array for key
-    public func readArray(forKey key: String) -> Array<Any>? {
-        return readObject(forKey: key) as? Array<Any>
+    public func readArray(forKey key: String) -> [Any]? {
+        return readObject(forKey: key) as? [Any]
     }
-    
+
     /// Read a dictionary for key
-    public func readDictionary(forKey key: String) -> Dictionary<AnyHashable, Any>? {
-        return readObject(forKey: key) as? Dictionary<AnyHashable, Any>
+    public func readDictionary(forKey key: String) -> [AnyHashable: Any]? {
+        return readObject(forKey: key) as? [AnyHashable: Any]
     }
-    
+
     // MARK: - Read & write image
-    
+
     /// Write image for key. Please use this method to write an image instead of `writeObject(_:forKey:)`
-    public func write(image: UIImage, forKey key: String, format: ImageFormat? = nil) {
-        var data: Data? = nil
-        
+    public func write(image: UIImage, forKey key: String, format: ImageFormat? = nil, alsoOnDisk: Bool = false) {
+        var data: Data?
+
         if let format = format, format == .png {
             data = image.pngData()
-        }
-        else {
+        } else {
             data = image.jpegData(compressionQuality: 0.9)
         }
-        
+
         if let data = data {
-            write(data: data, forKey: key)
+            write(data: data, forKey: key, alsoOnDisk: alsoOnDisk)
         }
     }
-    
+
     /// Read image for key. Please use this method to write an image instead of `readObject(forKey:)`
     public func readImage(forKey key: String) -> UIImage? {
         let data = readData(forKey: key)
         if let data = data {
             return UIImage(data: data, scale: 1.0)
         }
-        
+
         return nil
     }
-    
+
     @available(*, deprecated, message: "Please use `readImage(forKey:)` instead. This will be removed in the future.")
     public func readImageForKey(key: String) -> UIImage? {
         return readImage(forKey: key)
@@ -204,12 +220,12 @@ extension DataCache {
     public func hasData(forKey key: String) -> Bool {
         return hasDataOnDisk(forKey: key) || hasDataOnMem(forKey: key)
     }
-    
+
     /// Check if has data on disk
     public func hasDataOnDisk(forKey key: String) -> Bool {
         return self.fileManager.fileExists(atPath: self.cachePath(forKey: key))
     }
-    
+
     /// Check if has data on mem
     public func hasDataOnMem(forKey key: String) -> Bool {
         return (memCache.object(forKey: key as AnyObject) != nil)
@@ -219,17 +235,17 @@ extension DataCache {
 // MARK: - Clean
 
 extension DataCache {
-    
+
     /// Clean all mem cache and disk cache. This is an async operation.
     public func cleanAll() {
         cleanMemCache()
         cleanDiskCache()
     }
-    
+
     /// Clean cache by key. This is an async operation.
     public func clean(byKey key: String) {
         memCache.removeObject(forKey: key as AnyObject)
-        
+
         ioQueue.async {
             do {
                 try self.fileManager.removeItem(atPath: self.cachePath(forKey: key))
@@ -238,11 +254,11 @@ extension DataCache {
             }
         }
     }
-    
+
     public func cleanMemCache() {
         memCache.removeAllObjects()
     }
-    
+
     public func cleanDiskCache() {
         ioQueue.async {
             do {
@@ -252,25 +268,23 @@ extension DataCache {
             }
         }
     }
-    
+
     /// Clean expired disk cache. This is an async operation.
     @objc public func cleanExpiredDiskCache() {
         cleanExpiredDiskCache(completion: nil)
     }
-    
+
     // This method is from Kingfisher
     /**
      Clean expired disk cache. This is an async operation.
-     
+
      - parameter completionHandler: Called after the operation completes.
      */
-    open func cleanExpiredDiskCache(completion handler: (()->())? = nil) {
-        
+    open func cleanExpiredDiskCache(completion handler: (() -> Void)? = nil) {
         // Do things in cocurrent io queue
         ioQueue.async {
-            
             var (URLsToDelete, diskCacheSize, cachedFiles) = self.travelCachedFiles(onlyForCacheSize: false)
-            
+
             for fileURL in URLsToDelete {
                 do {
                     try self.fileManager.removeItem(at: fileURL)
@@ -278,44 +292,40 @@ extension DataCache {
                     print("DataCache: Error while removing files \(error.localizedDescription)")
                 }
             }
-            
+
             if self.maxDiskCacheSize > 0 && diskCacheSize > self.maxDiskCacheSize {
                 let targetSize = self.maxDiskCacheSize / 2
-                
+
                 // Sort files by last modify date. We want to clean from the oldest files.
-                let sortedFiles = cachedFiles.keysSortedByValue {
-                    resourceValue1, resourceValue2 -> Bool in
-                    
+                let sortedFiles = cachedFiles.keysSortedByValue { resourceValue1, resourceValue2 -> Bool in
                     if let date1 = resourceValue1.contentAccessDate,
-                       let date2 = resourceValue2.contentAccessDate
-                    {
+                       let date2 = resourceValue2.contentAccessDate {
                         return date1.compare(date2) == .orderedAscending
                     }
-                    
+
                     // Not valid date information. This should not happen. Just in case.
                     return true
                 }
-                
+
                 for fileURL in sortedFiles {
-                    
                     do {
                         try self.fileManager.removeItem(at: fileURL)
                     } catch {
                         print("DataCache: Error while removing files \(error.localizedDescription)")
                     }
-                    
+
                     URLsToDelete.append(fileURL)
-                    
+
                     if let fileSize = cachedFiles[fileURL]?.totalFileAllocatedSize {
                         diskCacheSize -= UInt(fileSize)
                     }
-                    
+
                     if diskCacheSize < targetSize {
                         break
                     }
                 }
             }
-            
+
             DispatchQueue.main.async(execute: { () -> Void in
                 handler?()
             })
@@ -326,37 +336,36 @@ extension DataCache {
 // MARK: - Helpers
 
 extension DataCache {
-    
+
     // This method is from Kingfisher
     fileprivate func travelCachedFiles(onlyForCacheSize: Bool) -> (urlsToDelete: [URL], diskCacheSize: UInt, cachedFiles: [URL: URLResourceValues]) {
-        
+
         let diskCacheURL = URL(fileURLWithPath: cachePath)
         let resourceKeys: Set<URLResourceKey> = [.isDirectoryKey, .contentAccessDateKey, .totalFileAllocatedSizeKey]
         let expiredDate: Date? = (maxCachePeriodInSecond < 0) ? nil : Date(timeIntervalSinceNow: -maxCachePeriodInSecond)
-        
+
         var cachedFiles = [URL: URLResourceValues]()
         var urlsToDelete = [URL]()
         var diskCacheSize: UInt = 0
-        
+
         for fileUrl in (try? fileManager.contentsOfDirectory(at: diskCacheURL, includingPropertiesForKeys: Array(resourceKeys), options: .skipsHiddenFiles)) ?? [] {
-            
+
             do {
                 let resourceValues = try fileUrl.resourceValues(forKeys: resourceKeys)
                 // If it is a Directory. Continue to next file URL.
                 if resourceValues.isDirectory == true {
                     continue
                 }
-                
+
                 // If this file is expired, add it to URLsToDelete
                 if !onlyForCacheSize,
                     let expiredDate = expiredDate,
                     let lastAccessData = resourceValues.contentAccessDate,
-                    (lastAccessData as NSDate).laterDate(expiredDate) == expiredDate
-                {
+                    (lastAccessData as NSDate).laterDate(expiredDate) == expiredDate {
                     urlsToDelete.append(fileUrl)
                     continue
                 }
-                
+
                 if let fileSize = resourceValues.totalFileAllocatedSize {
                     diskCacheSize += UInt(fileSize)
                     if !onlyForCacheSize {
@@ -367,12 +376,18 @@ extension DataCache {
                 print("DataCache: Error while iterating files \(error.localizedDescription)")
             }
         }
-        
+
         return (urlsToDelete, diskCacheSize, cachedFiles)
     }
-    
+
     func cachePath(forKey key: String) -> String {
-        let fileName = key.md5
+        let fileName: String
+        if #available(iOS 13, *) {
+            fileName = key.md5String
+        } else {
+            fileName =  = key.md5
+        }
+
         return (cachePath as NSString).appendingPathComponent(fileName)
     }
 }

--- a/Sources/String+MD5.swift
+++ b/Sources/String+MD5.swift
@@ -21,6 +21,10 @@
 
 import Foundation
 
+#if canImport(CryptoKit)
+  import CryptoKit
+#endif
+
 extension String {
     var md5: String {
         if let data = self.data(using: .utf8, allowLossyConversion: true) {
@@ -42,8 +46,17 @@ extension String {
             return self
         }
     }
-}
 
+#if canImport(CryptoKit)
+    var md5String: String {
+        let digest = Insecure.MD5.hash(data: self.data(using: .utf8) ?? Data())
+
+        return digest.map {
+            String(format: "%02hhx", $0)
+        }.joined()
+    }
+#endif
+}
 
 /** array of bytes, little-endian representation */
 func arrayOfBytes<T>(_ value: T, length: Int? = nil) -> [UInt8] {


### PR DESCRIPTION
Hi, thanks for you great library.

I'm updated the main class to make this more flexible and support the latest iOS 13 frameworks.

- Added support to define use only memory cache
- Added support to define, for each write method, if we want to store the data on disk
- Added support for iOS 13 API
- Updated string extension to support CryptoKit framework, for md5 hashes
- Clean code and added extra info to avoid SwiftLint warnings

